### PR TITLE
Use snake case for data sources folder

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -194,7 +194,7 @@ export async function generateFeatureArchitecture (
   // Create the data layer
   const dataDirectoryPath = path.join(featureDirectoryPath, "data");
   await createDirectories(dataDirectoryPath, [
-    "datasources",
+    "data_sources",
     "models",
     "repositories",
   ]);


### PR DESCRIPTION
VS code spell checker highlights "datasources" directory as the one which contains a typo if written like this. 

Using the "data_sources" instead fixes this.